### PR TITLE
Replace outdated links to Git for Windows' wiki

### DIFF
--- a/winget_git.ini
+++ b/winget_git.ini
@@ -1,5 +1,5 @@
 [Setup]
-; https://github.com/git-for-windows/git/wiki/Silent-or-Unattended-Installation
+; https://gitforwindows.org/silent-or-unattended-installation
 Lang=default
 Dir=C:\Program Files\Git
 Group=Git


### PR DESCRIPTION
Git for Windows' wiki pages were migrated in https://github.com/git-for-windows/git-for-windows.github.io/pull/59.